### PR TITLE
Fix toc options

### DIFF
--- a/ox-context.el
+++ b/ox-context.el
@@ -1508,10 +1508,7 @@ logfiles to remove, set `org-context-logfiles-extensions'."
    \\blank[2*medium]
    {\\tfa \\documentvariable{metadata:date}}
    \\blank[3*medium]
-  \\stopalignment}
-\\define\\OrgTitleContents{%
-  {\\tfc Contents}
-}")
+  \\stopalignment}")
     ;; LaTeX report style title setup
     ("title-report" . "\\setuphead[title][align=middle]
 \\definestartstop[OrgTitlePage]
@@ -1534,10 +1531,7 @@ logfiles to remove, set `org-context-logfiles-extensions'."
    {\\tfa \\documentvariable{metadata:date}}
    \\blank[3*medium]
   \\stopalignment
-  \\stopstandardmakeup}
-\\define\\OrgTitleContents{%
-  {\\tfc Contents}
-}")
+  \\stopstandardmakeup}")
     ;; LaTeX style tables of contents
     ("toc-article" . "\\setupcombinedlist[content][alternative=c]")
     ;; Indented verse blocks with spaces preserved

--- a/testing/test-ox-context.el
+++ b/testing/test-ox-context.el
@@ -6583,6 +6583,65 @@ FRONTMATTER
             '(:context-snippets (("TestSnippet" . "A Test Snippet"))))))))
     (should
      (string-match-p "A Test Snippet" document))))
+;;; Table of Contents
+(ert-deftest test-org-context/table-of-contents-off ()
+  "Turning the table of contents off."
+  (should-not
+   (string-match-p
+    (regexp-quote "\\placecontent")
+    (context-test-with-temp-text
+     "#+OPTIONS: toc:nil
+* First
 
+** Second"
+     (org-export-as 'context nil nil nil '(:context-preset "empty"))))))
+(ert-deftest test-org-context/table-of-contents-on ()
+  "Turning the table of contents on."
+  (should
+   (string-match-p
+    (regexp-quote "\\placecontent")
+    (context-test-with-temp-text
+     "#+OPTIONS: toc:1
+* First
+
+** Second"
+     (org-export-as 'context nil nil nil '(:context-preset "empty"))))))
+(ert-deftest test-org-context/table-of-contents-empty ()
+  "Requirethat table of contents does not appear if there are no headlines."
+  (should-not
+   (string-match-p
+    (regexp-quote "\\placecontent")
+    (context-test-with-temp-text
+     "#+OPTIONS: toc:1
+foo bar baz"
+     (org-export-as 'context nil nil nil '(:context-preset "empty"))))))
+(ert-deftest test-org-context/table-of-contents-levels ()
+  "Test the correct number of levels appear in the table of contents."
+  (should
+   (string-match-p
+    (regexp-quote "\\setupcombinedlist[content][list={section,subsection}]")
+    (context-test-with-temp-text
+     "#+OPTIONS: toc:2
+* First
+
+** Second
+
+*** Third
+
+**** Fourth"
+     (org-export-as 'context nil nil nil '(:context-preset "empty")))))
+  (should
+   (string-match-p
+    (regexp-quote "\\setupcombinedlist[content][list={section}]")
+    (context-test-with-temp-text
+     "#+OPTIONS: toc:1
+* First
+
+** Second
+
+*** Third
+
+**** Fourth"
+     (org-export-as 'context nil nil nil '(:context-preset "empty"))))))
 (provide 'test-ox-context)
 ;;; test-ox-context ends here

--- a/testing/test-ox-context.el
+++ b/testing/test-ox-context.el
@@ -4017,6 +4017,8 @@ baz & buz
      (org-trim (org-export-as 'context nil nil t '(:context-preset "empty")))))))
 (ert-deftest test-org-context/link-other ()
   "Test a link to an unsupported type."
+  ;; TODO Resolve this - There seems to have been a deprecation between
+  ;; org versions
   (should
    (equal
     "attachment:projects.org"

--- a/testing/test-ox-context.el
+++ b/testing/test-ox-context.el
@@ -6643,5 +6643,57 @@ foo bar baz"
 
 **** Fourth"
      (org-export-as 'context nil nil nil '(:context-preset "empty"))))))
+(ert-deftest test-org-context/table-of-contents-title-on-cust ()
+  "Show that table of contents appears when it's supposed to and accepts customization."
+  (let* ((org-context-toc-title-command
+          '("\\TestTitleContents" . "\\define\\TestTitleContents{}"))
+         (content (context-test-with-temp-text
+                   "#+OPTIONS: toc:1
+* First"
+                   (org-export-as 'context nil nil nil '(:context-preset "empty")))))
+    (should
+     (string-match-p
+      (regexp-quote "\\TestTitleContents
+\\placecontent" )
+      content))
+    (should
+     (string-match-p
+      (regexp-quote "\\define\\TestTitleContents{}")
+      content))))
+(ert-deftest test-org-context/table-of-contents-title-on-plist ()
+  "Show that table of contents appears when it's supposed to and accepts customization."
+  (let* ((content (context-test-with-temp-text
+                   "#+OPTIONS: toc:1
+* First"
+                   (org-export-as
+                    'context nil nil nil
+                    '(:context-preset "empty"
+                      :context-toc-title-command ("\\TestTitleContents" . "\\define\\TestTitleContents{}"))))))
+    (should
+     (string-match-p
+      (regexp-quote "\\TestTitleContents
+\\placecontent" )
+      content))
+    (should
+     (string-match-p
+      (regexp-quote "\\define\\TestTitleContents{}")
+      content))))
+(ert-deftest test-org-context/table-of-contents-title-off-plist ()
+  "Show that table of contents does not appear when not needed"
+  (let* ((content (context-test-with-temp-text
+                   "#+OPTIONS: toc:nil
+* First"
+                   (org-export-as
+                    'context nil nil nil
+                    '(:context-preset "empty"
+                      :context-toc-title-command ("\\TestTitleContents" . "\\define\\TestTitleContents{}"))))))
+    (should-not
+     (string-match-p
+      (regexp-quote "\\TestTitleContents" )
+      content))
+    (should-not
+     (string-match-p
+      (regexp-quote "\\define\\TestTitleContents{}")
+      content))))
 (provide 'test-ox-context)
 ;;; test-ox-context ends here


### PR DESCRIPTION
This addresses a bug identified in the mailing list where `#+OPTIONS: toc:nil` or `#+OPTIONS: toc:1` etc were not respected.