### PR TITLE
Respect :with-{author,date,title,email}

### DIFF
--- a/ox-context.el
+++ b/ox-context.el
@@ -1559,19 +1559,17 @@ logfiles to remove, set `org-context-logfiles-extensions'."
 \\define\\OrgMakeTitle{%
   \\startalignment[center]
    \\blank[force,2*big]
-   \\title{\\documentvariable{metadata:title}}
+   \\doifnot{\\documentvariable{metadata:title}}{}{
+     \\title{\\documentvariable{metadata:title}}}
    \\doifnot{\\documentvariable{metadata:subtitle}}{}{
      \\blank[force,1*big]
      \\tfa \\documentvariable{metadata:subtitle}}
-   \\doifelse{\\documentvariable{metadata:author}}{}{
-   \\blank[3*medium]
-   {\\tfa \\documentvariable{metadata:email}}
-   }{
-      \\blank[3*medium]
-      {\\tfa \\documentvariable{metadata:author}}
-   }
-   \\blank[2*medium]
-   {\\tfa \\documentvariable{metadata:date}}
+   \\doifnot{\\documentvariable{metadata:author}}{}{
+     \\blank[3*medium]
+     {\\tfa \\documentvariable{metadata:author}}}
+   \\doifnot{\\documentvariable{metadata:date}}{}{
+     \\blank[2*medium]
+     {\\tfa \\documentvariable{metadata:date}}}
    \\blank[3*medium]
   \\stopalignment}")
     ;; LaTeX report style title setup
@@ -1581,20 +1579,18 @@ logfiles to remove, set `org-context-logfiles-extensions'."
   \\startstandardmakeup[page=yes]
   \\startalignment[center]
    \\blank[force,2*big]
-    \\title{\\documentvariable{metadata:title}}
+   \\doifnot{\\documentvariable{metadata:title}}{}{
+     \\title{\\documentvariable{metadata:title}}}
    \\doifnot{\\documentvariable{metadata:subtitle}}{}{
      \\blank[force,1*big]
      \\tfa \\documentvariable{metadata:subtitle}}
-   \\doifelse{\\documentvariable{metadata:author}}{}{
-   \\blank[3*medium]
-   {\\tfa \\documentvariable{metadata:email}}
-   }{
-      \\blank[3*medium]
-      {\\tfa \\documentvariable{metadata:author}}
-   }
+   \\doifnot{\\documentvariable{metadata:author}}{}{
+     \\blank[3*medium]
+     {\\tfa \\documentvariable{metadata:author}}}
+   \\doifnot{\\documentvariable{metadata:date}}{}{
+     \\blank[2*medium]
+     {\\tfa \\documentvariable{metadata:date}}}
    \\blank[2*medium]
-   {\\tfa \\documentvariable{metadata:date}}
-   \\blank[3*medium]
   \\stopalignment
   \\stopstandardmakeup}")
     ;; LaTeX style tables of contents
@@ -4173,16 +4169,25 @@ Returns a string containing those definitions."
 INFO is a plist used as a communication channel."
   ;; TODO handle arbitrary metadata.
   (list
-    (cons "metadata:author" (org-export-data (plist-get info :author) info))
-    (cons "metadata:title" (org-export-data (plist-get info :title) info))
-    (cons "metadata:email" (org-export-data (plist-get info :email) info))
+    (cons "metadata:author"
+          (and (plist-get info :with-author)
+               (org-export-data (plist-get info :author) info)))
+    (cons "metadata:title"
+          (and (plist-get info :with-title)
+               (org-export-data (plist-get info :title) info)))
+    (cons "metadata:email"
+          (and (plist-get info :with-email)
+               (org-export-data (plist-get info :email) info)))
     (cons "metadata:subtitle" (org-export-data (plist-get info :subtitle) info))
     (cons "metadata:keywords" (org-export-data (plist-get info :keywords) info))
     (cons "metadata:description" (org-export-data (plist-get info :description) info))
     (cons "metadata:creator" (plist-get info :creator))
     (cons "metadata:language" (plist-get info :language))
     (cons "Lang" (capitalize (plist-get info :language)))
-    (cons "metadata:date" (org-export-data (org-export-get-date info) info))
+    (cons "metadata:date"
+          (and
+           (plist-get info :with-date)
+           (org-export-data (org-export-get-date info) info)))
     (cons "metadata:phonenumber" (org-export-data (plist-get info :phone-number) info))
     (cons "metadata:url" (org-export-data (plist-get info :url) info))
     (cons "metadata:subject" (org-export-data (plist-get info :subject) info))))


### PR DESCRIPTION
This also drops the convention to replace the author with the email by
default.

Fixes #33.